### PR TITLE
Implement navigation to results page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,26 +1,26 @@
 import { useState } from "react";
-import MainContainer from "./components/MainContainer";
-import InfoContainer from "./components/InfoContainer";
-import ShowData from "./components/ShowData";
+import { Routes, Route, useNavigate } from "react-router-dom";
+import Home from "./pages/Home";
+import Result from "./pages/Result";
 
 const App = () => {
   const [data, setData] = useState(null);
+  const navigate = useNavigate();
+
+  const handleFileUploaded = (fileData) => {
+    setData(fileData);
+    navigate("/resultado");
+  };
 
   return (
     <div className="w-2xl">
       <h1 className="text-3xl text-[var(--primary)] mb-6">
         Bem vindo ao site para automatizar suas finanças
       </h1>
-      <MainContainer className={data? "" : "flex justify-center items-center"}>
-        {data ? (
-          <ShowData data={data}/>
-        ) : (
-          <InfoContainer
-            info="Selecione ou arraste o arquivo para aqui"
-            onFileUploaded={setData}
-          />
-        )}
-      </MainContainer>
+      <Routes>
+        <Route path="/" element={<Home onFileUploaded={handleFileUploaded} />} />
+        <Route path="/resultado" element={<Result data={data} />} />
+      </Routes>
     </div>
   );
 };

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,13 @@
+import MainContainer from '../components/MainContainer';
+import InfoContainer from '../components/InfoContainer';
+
+const Home = ({ onFileUploaded }) => (
+  <MainContainer className="flex justify-center items-center">
+    <InfoContainer
+      info="Selecione ou arraste o arquivo para aqui"
+      onFileUploaded={onFileUploaded}
+    />
+  </MainContainer>
+);
+
+export default Home;

--- a/src/pages/Result.jsx
+++ b/src/pages/Result.jsx
@@ -1,0 +1,10 @@
+import MainContainer from '../components/MainContainer';
+import ShowData from '../components/ShowData';
+
+const Result = ({ data }) => (
+  <MainContainer>
+    {data ? <ShowData data={data} /> : <p>Nenhum dado disponível.</p>}
+  </MainContainer>
+);
+
+export default Result;


### PR DESCRIPTION
## Summary
- add Home and Result pages
- switch App.jsx to router-based navigation
- wrap application in BrowserRouter

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866fcab39748320a423a84fedfab993